### PR TITLE
Putting `-aarch64` in the postfix for arm64/aarch64 specific images.

### DIFF
--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -41,16 +41,16 @@ jobs:
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       -
-        name: Build and push - arm64
-        id: docker_build_arm64
+        name: Build and push - aarch64
+        id: docker_build_aarch64
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: bbsdocker/imageptt:latest,bbsdocker/imageptt:${{ steps.date.outputs.date }}
+          tags: bbsdocker/imageptt:latest,bbsdocker/imageptt:${{ steps.date.outputs.date }}-aarch64
           platforms: linux/arm64
           build-args: |
             MY_DEBIAN_VERSION=bullseye
             OPENRESTY_ARCH=arm64
       -
-        name: Image digest - arm64
-        run: echo ${{ steps.docker_build_arm64.outputs.digest }}
+        name: Image digest - aarch64
+        run: echo ${{ steps.docker_build_aarch64.outputs.digest }}

--- a/.github/workflows/push_container_sid.yml
+++ b/.github/workflows/push_container_sid.yml
@@ -41,16 +41,16 @@ jobs:
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       -
-        name: Build and push - arm64
-        id: docker_build_arm64
+        name: Build and push - aarch64
+        id: docker_build_aarch64
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: bbsdocker/imageptt:sid,bbsdocker/imageptt:sid-latest,bbsdocker/imageptt:sid-${{ steps.date.outputs.date }}
+          tags: bbsdocker/imageptt:sid,bbsdocker/imageptt:sid-latest,bbsdocker/imageptt:sid-${{ steps.date.outputs.date }}-aarch64
           platforms: linux/arm64
           build-args: |
             MY_DEBIAN_VERSION=sid
             OPENRESTY_ARCH=arm64
       -
-        name: Image digest - arm64
-        run: echo ${{ steps.docker_build_arm64.outputs.digest }}
+        name: Image digest - aarch64
+        run: echo ${{ steps.docker_build_aarch64.outputs.digest }}

--- a/.github/workflows/push_container_testing.yml
+++ b/.github/workflows/push_container_testing.yml
@@ -41,16 +41,16 @@ jobs:
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       -
-        name: Build and push - arm64
-        id: docker_build_arm64
+        name: Build and push - aarch64
+        id: docker_build_aarch64
         uses: docker/build-push-action@v5
         with:
           push: true
-          tags: bbsdocker/imageptt:bookworm,bbsdocker/imageptt:bookworm-latest,bbsdocker/imageptt:bookworm-${{ steps.date.outputs.date }}
+          tags: bbsdocker/imageptt:bookworm,bbsdocker/imageptt:bookworm-latest,bbsdocker/imageptt:bookworm-${{ steps.date.outputs.date }}-aarch64
           platforms: linux/arm64
           build-args: |
             MY_DEBIAN_VERSION=bookworm
             OPENRESTY_ARCH=arm64
       -
-        name: Image digest - arm64
-        run: echo ${{ steps.docker_build_arm64.outputs.digest }}
+        name: Image digest - aarch64
+        run: echo ${{ steps.docker_build_aarch64.outputs.digest }}


### PR DESCRIPTION
As discussed in https://github.com/bbsdocker/imageptt/issues/5, following the convention by [openresty](https://hub.docker.com/r/openresty/openresty/tags?name=bullseye), we put `-aarch64` in the postfix for arm64/aarch64 specific images.